### PR TITLE
Add FEN input field for chess positions

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -228,10 +228,19 @@
         stockfish.postMessage(`uci`);
       };
 
+      const getPositionCommand = () => {
+        const fen = $("#fen").value.trim();
+        if (fen.length > 0) {
+          return `position fen ${fen}`;
+        } else {
+          return `position startpos`;
+        }
+      };
+
       const setVariant = () => {
         const variant = $("#variant").value;
         stockfish.postMessage(`setoption name UCI_Variant value ${variant}`);
-        stockfish.postMessage(`position startpos`);
+        stockfish.postMessage(getPositionCommand());
         output = "";
         stockfish.postMessage(`d`);
       };
@@ -391,7 +400,7 @@
           FS.writeFile(filename, array);
           stockfish.postMessage(`setoption name EvalFile value ${filename}`);
           stockfish.postMessage(`setoption name UCI_Variant value ${variant}`);
-          stockfish.postMessage(`position startpos`);
+          stockfish.postMessage(getPositionCommand());
           stockfish.postMessage(`eval`);
         }
       };
@@ -507,6 +516,10 @@
                 ...variants.map((ex, index) => m("option", { value: ex }, ex)),
               ],
             ),
+            m("input#fen", {
+              placeholder: "FEN (optional)",
+              disabled: !is_ready,
+            }),
             m("input#threads", {
               placeholder: "Threads",
               disabled: !is_ready,

--- a/public/index.html
+++ b/public/index.html
@@ -271,6 +271,12 @@
         stockfish.postMessage(`setoption name multipv value ${multipv}`);
       };
 
+      const setPosition = () => {
+        stockfish.postMessage(getPositionCommand());
+        output = "";
+        stockfish.postMessage(`d`);
+      };
+
       const generate = () => {
         let args = "";
         const bookdepth = $("#bookdepth").value;
@@ -519,6 +525,7 @@
             m("input#fen", {
               placeholder: "FEN (optional)",
               disabled: !is_ready,
+              onchange: setPosition,
             }),
             m("input#threads", {
               placeholder: "Threads",


### PR DESCRIPTION
- Add optional FEN input field in settings section
- Create getPositionCommand() helper that returns "position fen [fen]" when FEN is provided, otherwise "position startpos"
- Update setVariant() to use FEN if provided
- Update onSelectNnueFile() to use FEN if provided

This allows users to start analysis from a custom chess position by providing a FEN string instead of always using the starting position.